### PR TITLE
Defonce modal-content to protect against app reloads

### DIFF
--- a/src/reagent_modals/modals.cljs
+++ b/src/reagent_modals/modals.cljs
@@ -10,9 +10,9 @@
 
 (def modal-id "reagent-modal")
 
-(def modal-content (atom {:content [:div]
-                          :shown nil
-                          :size nil}))
+(defonce modal-content (atom {:content [:div]
+                              :shown nil
+                              :size nil}))
 
 (defn get-modal []
   (dom/getElement modal-id))


### PR DESCRIPTION
If the modal is visible when the app reloads in development it disappears! Changing the state atom to a `defonce` should fix this.

Thanks for writing this great little library!
